### PR TITLE
🔧 Add workflows for previewing and submitting course

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,18 @@
+name: Create Preview Draft from PR
+on:
+  pull_request:
+    branches: ['main']
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  draft:
+    uses: curvenote/actions/.github/workflows/draft.yml@v1
+    with:
+      venue: ophusgroup
+      kind: course
+      collection: courses
+      id-pattern-regex: '^colab-[a-zA-Z0-9_-]{1,30}$'
+    secrets:
+      CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
+      GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,17 @@
+name: Create Submission from Main
+on:
+  push:
+    branches: ['main']
+permissions:
+  contents: write
+jobs:
+  submit:
+    uses: curvenote/actions/.github/workflows/submit.yml@v1
+    with:
+      venue: ophusgroup
+      kind: course
+      collection: courses
+      id-pattern-regex: '^colab-[a-zA-Z0-9_-]{1,30}$'
+    secrets:
+      CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
+      GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/myst.yml
+++ b/myst.yml
@@ -1,7 +1,7 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 project:
-  id: teaching-matsci144
+  id: colab-teaching-matsci144
   title: "Thermodynamic Evaluation of Green Energy Technologies"
   description: "MATSCI 144: Course Reader"
   short_title: MATSCI 144


### PR DESCRIPTION
This PR adds actions to submit the preview and submit the MyST contents as a `course` on the ophusgroup lab site.